### PR TITLE
Only accept patch changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jsdox": "^0.4.1",
-    "lodash": "^2.4.1",
-    "q": "^1.0.1"
+    "jsdox": "~0.4.4",
+    "lodash": "~2.4.1",
+    "q": "~1.0.1"
   },
   "devDependencies": {
     "grunt": "0.4.x",


### PR DESCRIPTION
This should better prevent breakages by only allowing patch versions to get updated at install-time.
